### PR TITLE
Create proper sample entry types when opening a file.

### DIFF
--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -46,22 +46,15 @@ MP4Err MP4ParseAtomUsingProtoList(MP4InputStreamPtr inputStream, u32 *protoList,
                                   MP4AtomPtr *outAtom);
 
 #ifdef ISMACrypt
-u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,
-                              MP4VisualSampleEntryAtomType,
-                              MP4AudioSampleEntryAtomType,
-                              MP4EncAudioSampleEntryAtomType,
-                              MP4EncVisualSampleEntryAtomType,
-                              MP4XMLMetaSampleEntryAtomType,
-                              MP4TextMetaSampleEntryAtomType,
-                              MP4AMRSampleEntryAtomType,
-                              MP4AWBSampleEntryAtomType,
-                              MP4AMRWPSampleEntryAtomType,
-                              MP4H263SampleEntryAtomType,
-                              MP4RestrictedVideoSampleEntryAtomType,
-                              ISOAVCSampleEntryAtomType,
-                              ISOHEVCSampleEntryAtomType,
-                              ISOVVCSampleEntryAtomType,
-                              0};
+u32 MP4SampleEntryProtos[] = {
+  MP4MPEGSampleEntryAtomType,      MP4VisualSampleEntryAtomType,
+  MP4AudioSampleEntryAtomType,     MP4EncAudioSampleEntryAtomType,
+  MP4EncVisualSampleEntryAtomType, MP4XMLMetaSampleEntryAtomType,
+  MP4TextMetaSampleEntryAtomType,  MP4AMRSampleEntryAtomType,
+  MP4AWBSampleEntryAtomType,       MP4AMRWPSampleEntryAtomType,
+  MP4H263SampleEntryAtomType,      MP4RestrictedVideoSampleEntryAtomType,
+  ISOAVCSampleEntryAtomType,       ISOHEVCSampleEntryAtomType,
+  ISOVVCSampleEntryAtomType,       0};
 #else
 u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,
                               MP4VisualSampleEntryAtomType,

--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -58,6 +58,9 @@ u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,
                               MP4AMRWPSampleEntryAtomType,
                               MP4H263SampleEntryAtomType,
                               MP4RestrictedVideoSampleEntryAtomType,
+                              ISOAVCSampleEntryAtomType,
+                              ISOHEVCSampleEntryAtomType,
+                              ISOVVCSampleEntryAtomType,
                               0};
 #else
 u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,

--- a/IsoLib/libisomediafile/src/MP4Atoms.c
+++ b/IsoLib/libisomediafile/src/MP4Atoms.c
@@ -258,7 +258,9 @@ MP4Err MP4CreateAtom(u32 atomType, MP4AtomPtr *outAtom)
 
   case MP4VisualSampleEntryAtomType:
   case ISOAVCSampleEntryAtomType:
+  case ISOHEVCSampleEntryAtomType:
   case MP4H263SampleEntryAtomType:
+  case ISOVVCSampleEntryAtomType:
     err = MP4CreateVisualSampleEntryAtom((MP4VisualSampleEntryAtomPtr *)&newAtom);
     break;
 

--- a/IsoLib/libisomediafile/src/VVCConfigAtom.c
+++ b/IsoLib/libisomediafile/src/VVCConfigAtom.c
@@ -284,8 +284,10 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
       GET8_V(x);
       self->native_ptl.ptl_frame_only_constraint_flag = (x & 0x80) >> 7;
       self->native_ptl.ptl_multi_layer_enabled_flag   = (x & 0x40) >> 6;
-      DEBUG_SPRINTF("ptl_frame_only_constraint_flag = %u", self->native_ptl.ptl_frame_only_constraint_flag);
-      DEBUG_SPRINTF("ptl_multi_layer_enabled_flag = %u", self->native_ptl.ptl_multi_layer_enabled_flag);
+      DEBUG_SPRINTF("ptl_frame_only_constraint_flag = %u",
+                    self->native_ptl.ptl_frame_only_constraint_flag);
+      DEBUG_SPRINTF("ptl_multi_layer_enabled_flag = %u",
+                    self->native_ptl.ptl_multi_layer_enabled_flag);
 
       self->native_ptl.general_constraint_info_upper = x & 0x3f;
       if(self->native_ptl.num_bytes_constraint_info > 1)

--- a/IsoLib/libisomediafile/src/VVCConfigAtom.c
+++ b/IsoLib/libisomediafile/src/VVCConfigAtom.c
@@ -251,6 +251,8 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
   GET8_V(x);
   self->LengthSizeMinusOne = (x & 0x06) >> 1;
   self->ptl_present_flag   = x & 0x01;
+  DEBUG_SPRINTF("LengthSizeMinusOne = %u", self->LengthSizeMinusOne);
+  DEBUG_SPRINTF("ptl_present_flag = %u", self->ptl_present_flag);
 
   if(self->ptl_present_flag)
   {
@@ -263,6 +265,10 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
     GET8_V(x);
     self->bit_depth_minus8 = (x & 0xe0) >> 5;
 
+    DEBUG_SPRINTF("num_sublayers = %u", self->num_sublayers);
+    DEBUG_SPRINTF("chroma_format_idc = %u", self->chroma_format_idc);
+    DEBUG_SPRINTF("bit_depth_minus8 = %u", self->bit_depth_minus8);
+
     /* PTL recoder */
     {
       GET8_V(x);
@@ -271,12 +277,16 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
       GET8_V(x);
       self->native_ptl.general_profile_idc = (x & 0xfe) >> 1;
       self->native_ptl.general_tier_flag   = x & 0x01;
+      DEBUG_SPRINTF("general_profile_idc = %u", self->native_ptl.general_profile_idc);
+      DEBUG_SPRINTF("general_tier_flag = %u", self->native_ptl.general_tier_flag);
 
       GET8(native_ptl.general_level_idc);
 
       GET8_V(x);
       self->native_ptl.ptl_frame_only_constraint_flag = (x & 0x80) >> 7;
       self->native_ptl.ptl_multi_layer_enabled_flag   = (x & 0x40) >> 6;
+      DEBUG_SPRINTF("ptl_frame_only_constraint_flag = %u", self->native_ptl.ptl_frame_only_constraint_flag);
+      DEBUG_SPRINTF("ptl_multi_layer_enabled_flag = %u", self->native_ptl.ptl_multi_layer_enabled_flag);
 
       self->native_ptl.general_constraint_info = x & 0x3f;
       for(u32 i = 1; i < self->native_ptl.num_bytes_constraint_info; i++)
@@ -322,6 +332,7 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
     GET8_V(x);
     self->arrays[array_index].array_completeness = (x & 0x80) ? 1 : 0;
     self->arrays[array_index].NALtype            = x & 0x1f;
+    DEBUG_SPRINTF("NALtype = %u", self->arrays[array_index].NALtype);
     err = MP4MakeLinkedList(&self->arrays[array_index].nalList);
     if(err) goto bail;
 


### PR DESCRIPTION
I noticed that when calling `ISOOpenMovieFile` AVC, HEVC and now also VVC sample entries are not created. those are just handled as `Generic Sample Entry` types. This PR fixes it and also adds a few debug messages for vccC. 

Open your file using `MP4OpenMovieDebug` flag to see what's inside.

```cpp
ISOOpenMovieFile("filePath", MP4OpenMovieDebug);
```

Also note that while `vvc_basic_track.mp4` is parsed without issues. All the remaining VVC test vectors from Nokia still fail.